### PR TITLE
Fixing blocked-list parameter to support entity type and pattern in p…

### DIFF
--- a/pii_check/pii_check_hook.py
+++ b/pii_check/pii_check_hook.py
@@ -23,7 +23,7 @@ def get_payload(content, enabled_entity_list, blocked_list):
     if blocked_list:
         blocked_list_payload = []
         if (blocked_list % 2) != 0:
-            sys.exit("Uneven number of blocked list parameters. Please provide parameters as 'ENTITY TYPE' - 'PATTERN' pairs in config")
+            sys.exit("Uneven number of blocked list parameters. Please provide parameters as space-separated 'ENTITY TYPE' 'PATTERN' pairs in config")
             
         type_pattern_pairs = [blocked_list[i:i + 2] for i in range(0, len(blocked_list), 2)]
         for entity_type, block_pattern in type_pattern_pairs:

--- a/pii_check/pii_check_hook.py
+++ b/pii_check/pii_check_hook.py
@@ -22,8 +22,12 @@ def get_payload(content, enabled_entity_list, blocked_list):
 
     if blocked_list:
         blocked_list_payload = []
-        for block_pattern in blocked_list:
-            curr_block_item = {"type": "BLOCK", "value": block_pattern}
+        if (blocked_list % 2) != 0:
+            sys.exit("Uneven number of blocked list parameters. Please provide parameters as 'ENTITY TYPE' - 'PATTERN' pairs in config")
+            
+        type_pattern_pairs = [blocked_list[i:i + 2] for i in range(0, len(blocked_list), 2)]
+        for entity_type, block_pattern in type_pattern_pairs:
+            curr_block_item = {"type": "BLOCK", "entity_type": entity_type, "pattern": block_pattern}
             blocked_list_payload.append(curr_block_item)
         payload["entity_detection"]["filter"] = blocked_list_payload
 


### PR DESCRIPTION
fixed an issue with the blocked list parameter where it did not properly take in both an entity_type and the pattern.
The fix here will allow the config to be passed as pairs of parameter values that specify entity type then it's pattern. 
If there is an odd number of parameters, it will throw an error. 