### PR TITLE
Fix failing pre-commit hook fails on directories

### DIFF
--- a/pii_check/pii_check_hook.py
+++ b/pii_check/pii_check_hook.py
@@ -37,7 +37,7 @@ def get_payload(content, enabled_entity_list, blocked_list):
 def get_flagged_lines(files):
     flagged = []
     for file in files:
-        if os.path.exists(file):
+        if os.path.exists(file) and not os.path.isdir(file):
             with open(file, "r") as fp:
                 lines = fp.readlines()
                 start_flag = False

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+pytest==7.2.1
+pytest-check==2.1.2
+python-dotenv==0.19.0
+requests==2.28.1

--- a/tests/test_data/dir_with_files/file_with_pii.txt
+++ b/tests/test_data/dir_with_files/file_with_pii.txt
@@ -1,0 +1,1 @@
+Credit card number: 1234 5678 9101 1123

--- a/tests/test_data/dir_with_files/file_with_pii_flag
+++ b/tests/test_data/dir_with_files/file_with_pii_flag
@@ -1,0 +1,10 @@
+PII_CHECK:OFF
+Some content in between the flags. Ideally this content won't be checked for PII.
+Below is a dummy PII to check this
+Credit card number: 1234 5678 9101 1123
+CVV: 123
+PII_CHECK:ON
+
+Some content where the check will be performed.
+Credit card number: 1234 5678 9101 1123
+CVV: 123

--- a/tests/test_data/dir_with_files/file_without_pii.txt
+++ b/tests/test_data/dir_with_files/file_without_pii.txt
@@ -1,0 +1,1 @@
+Here's some content.

--- a/tests/test_data/symlink_of_dir_with_files
+++ b/tests/test_data/symlink_of_dir_with_files
@@ -1,0 +1,1 @@
+./dir_with_files

--- a/tests/test_get_flagged_lines.py
+++ b/tests/test_get_flagged_lines.py
@@ -1,0 +1,13 @@
+import pytest_check as check
+from pii_check.pii_check_hook import get_flagged_lines
+
+
+def test_get_flagged_lines():
+    files = [
+        "tests/test_data/dir_with_files/file_with_pii.txt", "tests/test_data/dir_with_files/file_without_pii.txt",
+        "tests/test_data/dir_with_files/file_with_pii_flag_on", "tests/test_data/dir_with_files/file_with_pii_flag_off",
+        "tests/test_data/dir_with_files/file_with_pii_flag", "tests/test_data/symlink_of_dir_with_files"
+    ]
+    res = get_flagged_lines(files)
+    check.equal(res, [(1, 6, 'tests/test_data/dir_with_files/file_with_pii_flag')])
+


### PR DESCRIPTION
<!--- Fill in the applicable sections. Remove the sections which you don't need -->

## Purpose

**Why this PR?**
When the change is in directory, pre-commit hook fails with error.

Adding a symlink in text/symlink raise this error:

```
Check Yaml...........................................(no files to check)Skipped
Format code (black)......................................................Passed
Sort imports (isort).....................................................Passed
Check for PII............................................................Failed
- hook id: pii-check
- duration: 0.11s
- exit code: 1

Traceback (most recent call last):
  File "/home/guydumais/.cache/pre-commit/repomg4xos05/py_env-python3.8/bin/pii_check", line 8, in <module>
    sys.exit(main())
  File "/home/guydumais/.cache/pre-commit/repomg4xos05/py_env-python3.8/lib/python3.8/site-packages/pii_check/pii_check_hook.py", line 155, in main
    check_for_pii(args.url, API_KEY, enabled_entity_list)
  File "/home/guydumais/.cache/pre-commit/repomg4xos05/py_env-python3.8/lib/python3.8/site-packages/pii_check/pii_check_hook.py", line 104, in check_for_pii
    flagged = get_flagged_lines(files)
  File "/home/guydumais/.cache/pre-commit/repomg4xos05/py_env-python3.8/lib/python3.8/site-packages/pii_check/pii_check_hook.py", line 36, in get_flagged_lines
    with open(file, "r") as fp:
IsADirectoryError: [Errno 21] Is a directory: 'text/symlink'
```

The error is a result of checking the `PII_CHECK` flag on changed files and dirs.

## Description

**What is changed?**
- Skip `PII_CHECK` flag check for directories.
- Add unittest for `get_flagged_lines()`

**How has this been tested?**
- Running unittest.
- Installing updated version of pre-commit hook and testing on the failing case.


## Checklist

- [x] No linting error?
- [x] No dead code?